### PR TITLE
Fix/pixel size type hint

### DIFF
--- a/src/ngio/ome_zarr_meta/ngio_specs/_pixel_size.py
+++ b/src/ngio/ome_zarr_meta/ngio_specs/_pixel_size.py
@@ -2,7 +2,6 @@
 
 import math
 from functools import total_ordering
-from typing import overload
 
 import numpy as np
 from pydantic import BaseModel

--- a/src/ngio/ome_zarr_meta/ngio_specs/_pixel_size.py
+++ b/src/ngio/ome_zarr_meta/ngio_specs/_pixel_size.py
@@ -72,13 +72,7 @@ class PixelSize(BaseModel):
         """Return the pixel size as a dictionary."""
         return {"t": self.t, "z": self.z, "y": self.y, "x": self.x}
 
-    @overload
-    def get(self, axis: str, default: float) -> float: ...
-
-    @overload
-    def get(self, axis: str, default: None = None) -> float | None: ...
-
-    def get(self, axis: str, default: float | None = None) -> float | None:
+    def get(self, axis: str, default: float | None = None) -> float:
         """Get the pixel size for a given axis (in canonical name)."""
         px_size = self.as_dict().get(axis, default)
         if px_size is None:


### PR DESCRIPTION
Removed the overloaded type hints, assuming this is the intended behaviour:
```
axis exists -> float
axis does not exist, default: float -> float
axis does not exist, default = None -> raises
```

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`

No entry required IMO