### PR TITLE
Update github actions and introduce zizmor scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(dependabot):"
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /.github/workflows
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(dependabot):"
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: "quarterly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
       interval: "quarterly"
     cooldown:
       default-days: 7
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   check-manifest:
     # check-manifest is a tool that checks that all files in version control are
     # included in the sdist (unless explicitly excluded)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: pipx run check-manifest
 
   setup:
@@ -65,16 +65,16 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🔧 Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           environments: ${{ matrix.environment }}
 
       - name: Restore shared data cache
         id: cache-data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: data/
           key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
@@ -87,7 +87,7 @@ jobs:
       # If something goes wrong with scheduled tests, open an issue in the repo
       - name: 📝 Report Failures
         if: failure() && github.event_name == 'schedule'
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: ${{ matrix.platform }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Coverage
         if: success() && matrix.platform == 'ubuntu-latest'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /home/runner/work/ngio/ngio/coverage.xml
@@ -119,12 +119,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           cache: "pip"
@@ -136,9 +136,9 @@ jobs:
           python -m build
 
       - name: 🚢 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: "./dist/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: pipx run check-manifest
+      - run: pipx run --spec check-manifest==0.51 check-manifest
 
   setup:
     # Outputs a reduced matrix for PRs, full matrix for main/tags/schedule

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -39,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: pipx run --spec check-manifest==0.51 check-manifest
 
   setup:
@@ -63,9 +69,14 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.setup.outputs.matrix) }}
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 🔧 Set up pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
@@ -122,6 +133,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
 
       - name: 👷 Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Restore/save shared data cache (trusted)
         if: github.event_name != 'pull_request'
         id: cache-data
+        # zizmor: ignore[cache-poisoning] -- restricted to trusted (non pull_request)
+        # triggers above; PR runs use the read-only restore step instead, so this
+        # cache can't be poisoned by untrusted code.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: data/
@@ -162,4 +165,4 @@ jobs:
       - name: 🚢 Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" ./dist/* --generate-notes
+        run: gh release create "${GITHUB_REF_NAME}" ./dist/* --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,18 @@ jobs:
         with:
           environments: ${{ matrix.environment }}
 
-      - name: Restore shared data cache
+      - name: Restore shared data cache (PR — read-only)
+        if: github.event_name == 'pull_request'
+        id: cache-data-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: data/
+          key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
+          restore-keys: |
+            "${{ runner.os }}-data-"
+
+      - name: Restore/save shared data cache (trusted)
+        if: github.event_name != 'pull_request'
         id: cache-data
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -148,7 +159,7 @@ jobs:
       - name: 🚢 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          generate_release_notes: true
-          files: "./dist/*"
+      - name: 🚢 Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" ./dist/* --generate-notes

--- a/.github/workflows/ci_upstream.yml
+++ b/.github/workflows/ci_upstream.yml
@@ -30,10 +30,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
           cache: "pip"
@@ -45,7 +45,7 @@ jobs:
           python -m pip install .[test]
 
       - name: Restore shared data cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: data/
           key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
@@ -57,7 +57,7 @@ jobs:
 
       - name: 📝 Report Failures
         if: failure() && github.event_name == 'schedule'
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: ubuntu-latest
@@ -77,10 +77,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
           cache: "pip"
@@ -92,7 +92,7 @@ jobs:
           python -m pip install .[test] --pre
 
       - name: Restore shared data cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: data/
           key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
@@ -104,7 +104,7 @@ jobs:
 
       - name: 📝 Report Failures
         if: failure()
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: ubuntu-latest

--- a/.github/workflows/ci_upstream.yml
+++ b/.github/workflows/ci_upstream.yml
@@ -20,10 +20,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   test-pip:
     name: pip (stable)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
     # For workflow_run: only proceed if the main CI succeeded
     if: >
       github.event_name != 'workflow_run' ||
@@ -31,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true  # TODO: set to false and check if it is needed
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -71,6 +79,10 @@ jobs:
   test-pip-pre:
     name: pip (--pre)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
     # For workflow_run: only proceed if the main CI succeeded
     if: >
       github.event_name != 'workflow_run' ||
@@ -78,6 +90,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true  # TODO: set to false and check if it is needed
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci_upstream.yml
+++ b/.github/workflows/ci_upstream.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true  # TODO: set to false and check if it is needed
+          persist-credentials: false
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true  # TODO: set to false and check if it is needed
+          persist-credentials: false
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,15 +41,6 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      # TODO: Check whether this cache is actually used for building the docs
-      # - name: Restore shared data cache
-      #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      #   with:
-      #     path: data/
-      #     key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
-      #     restore-keys: |
-      #       "${{ runner.os }}-data-"
-
       - name: Deploy docs
         run: |
           VERSION=$(echo $GITHUB_REF | sed 's/refs\/tags\///' | sed 's/refs\/heads\///')

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,12 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: true # TODO: is this needed?
 
       - name: 🔧 Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           environments: docs
 
@@ -37,7 +38,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
       - name: Restore shared data cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: data/
           key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,6 @@ jobs:
     permissions:
       contents: read
       pages: write
-      # TODO: anything else?
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,13 +41,14 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      - name: Restore shared data cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: data/
-          key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
-          restore-keys: |
-            "${{ runner.os }}-data-"
+      # TODO: Check whether this cache is actually used for building the docs
+      # - name: Restore shared data cache
+      #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      #   with:
+      #     path: data/
+      #     key: "${{ runner.os }}-data-${{ hashFiles('tests/conftest.py') }}"
+      #     restore-keys: |
+      #       "${{ runner.os }}-data-"
 
       - name: Deploy docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ jobs:
     name: Deploy Docs
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pages: write
+      # TODO: anything else?
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: true # TODO: is this needed?
+          persist-credentials: false
 
       - name: 🔧 Set up pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # contents: read # only needed for private or internal repos
+      # actions: read # only needed for private or internal repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,7 @@
-name: GitHub Actions Security Analysis with zizmor 🌈
+# Security analysis with zizmor
+#
+# Scope:    Runs on every push and PR to main. Uses zizmor to analyze GitHub Actions workflows for security issues.
+name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,7 +1,7 @@
 # Security analysis with zizmor
 #
 # Scope:    Runs on every push and PR to main. Uses zizmor to analyze GitHub Actions workflows for security issues.
-name: GitHub Actions Security Analysis with zizmor
+name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Chores
+- Harden GitHub Actions and scan workflows through `zizmor`.
+
 ## [v0.5.11]
 
 ### Fix


### PR DESCRIPTION
Hi @lorenzocerrone, I'm opening this PR after the discussion I started elsewhere. Depending on your take on this, I can also reduce the scope of the PR and only introduce a subset of changes - let's perhaps review it together.

What is included:
1. There is a new action based on https://docs.zizmor.sh (which is also the tool I used to scan the current ones). Note that this will likely have some warnings, even after the current PR (here is [an example of how they look](https://github.com/fractal-analytics-platform/fractal-data/security/code-scanning?query=is%3Aclosed+branch%3Amain+tool%3Azizmor)).
2. All 3rd-party actions are pinned to a commit hash, rather than to a mutable tag (ref https://docs.zizmor.sh/audits/#ref-confusion).
3. To keep 3rd-party actions somewhat up-to-date, I configured dependabot so that it creates a PR every quarter, with a grouped update of all relevant actions (and with a 7-days cool-down window).
4. I also pinned the version of tools that are called directly through a `run` step (I only spotted `pipx run check-manifest`).
5. I reduced permissions as much as it seemed appropriate - ref https://docs.zizmor.sh/audits/#excessive-permissions.
6. I removed the caching step from the documentation workflow, since it I couldn't find an actual usage of it (maybe I missed it!) and it's best to avoid using caches in workflows that lead to deployments (like publishing the docs, or publishing a release). Ref https://docs.zizmor.sh/audits/#cache-poisoning.

What is still needed:
1. Most importantly: A review that I did not break anything. It's likely that some 3rd-party action has hidden assumption about what permissions they need, and they will break the next time they run. I looked at their docs when available, but often they do not include this information. I can make changes where needed - but I cannot run workflows on this repo and therefore I cannot check myself.
2. Overall: a review of the tradeoffs. On the one hand, if this PR introduces too much development friction we can also relax some constraints. On the other hand, we can also proceed and improve actions a bit further if you'd like to. An example would be replacing the `softprops` external actions with direct calls to `gh release` - similar to https://github.com/fractal-analytics-platform/fractal-data/blob/672fc29c09252444620bf90866d8830560e90f39/.github/workflows/github_release.yaml#L61-L64. Or, possibly, review the `workflow_run` usage.




## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
