### PR TITLE
Fix cache=True staleness on pre-opened groups + RoiTable Self annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - `find_dimension_separator` accepts the v2 chunk-key encoding on zarr v3 arrays, so deriving from such stores no longer fails.
 - Serialising a ROI table warns once per unknown extra column instead of once per ROI, the message explains the round-trip consequence, and `confidence` — written by `detect` — is recognised and no longer warns.
 - Stale table names are skipped by typed listings instead of *creating* a group for the missing table; shards clip to whole chunk multiples instead of producing a geometry zarr rejects; `mode="coarsen"` asked to upsample raises a named error instead of a bare divide-by-zero; a dropped channel selection is no longer validated before the removal that exempted it; a zero-sized axis reports itself instead of blaming the tail policy; stitch plan warnings fire at the start of `map`, pointing at the caller, not mid-run from a worker.
+- `create_ome_zarr_from_array(store=<pre-opened zarr.Group>)` failed validating `{}`: the populate step's cached reopen trusted the caller group's in-memory attributes, which predate the metadata write. A `cache=True` handler built on a pre-opened group now takes its first attribute read from the store — the canonical `plate.get_image_store(...) → create_ome_zarr_from_array(...)` converter pattern works again.
+- `GenericRoiTableV1.from_table_data` returns `Self` again, not the base class — the narrowed annotation made `RoiTableV1` fail the `Table` protocol under type checkers, flagging every downstream `add_table(name, roi_table)`.
 
 ### Behaviour changes
 

--- a/src/ngio/tables/v1/_roi_table.py
+++ b/src/ngio/tables/v1/_roi_table.py
@@ -6,7 +6,7 @@ https://fractal-analytics-platform.github.io/fractal-tasks-core/tables/
 
 import logging
 from collections.abc import Iterable, Mapping
-from typing import Any, Literal
+from typing import Any, Literal, Self
 from uuid import uuid4
 
 import pandas as pd
@@ -466,9 +466,7 @@ class GenericRoiTableV1(AbstractBaseTable):
         return roi
 
     @classmethod
-    def from_table_data(
-        cls, table_data: TabularData, meta: BackendMeta
-    ) -> "GenericRoiTableV1":
+    def from_table_data(cls, table_data: TabularData, meta: BackendMeta) -> Self:
         """Create a new ROI table from a table data."""
         _, rois = _table_to_rois(
             table=table_data,

--- a/src/ngio/utils/_zarr_utils.py
+++ b/src/ngio/utils/_zarr_utils.py
@@ -161,6 +161,14 @@ class ZarrGroupHandler:
 
         group = open_group_wrapper(store=store, mode=mode, zarr_format=zarr_format)
         self._group = group
+        # A caller-supplied, already-open group carries whatever attributes were
+        # in memory when the *caller* opened it — writes made since, e.g.
+        # through another handler on the same store, are invisible to that
+        # snapshot. `cache=True` would trust and pin it, so the first cached
+        # read reopens from the store instead (see `load_attrs`). Groups ngio
+        # opened itself are fresh by construction, and `open_group_wrapper`
+        # hands back a new object whenever it had to reopen.
+        self._attrs_maybe_stale = group is store
         self.use_cache = cache
 
         self._group_cache: NgioCache[zarr.Group] = NgioCache(use_cache=cache)
@@ -313,12 +321,16 @@ class ZarrGroupHandler:
         """
         mode = "r" if self.read_only else "r+"
         group = self.reopen_group()
-        return ZarrGroupHandler(
+        handler = ZarrGroupHandler(
             store=group,
             zarr_format=group.metadata.zarr_format,
             cache=self.use_cache,
             mode=mode,
         )
+        # `reopen_group` just read the group from the store; the pre-opened
+        # safety reopen would be a redundant round-trip.
+        handler._attrs_maybe_stale = False
+        return handler
 
     def invalidate_meta(self) -> None:
         """Drop cached metadata, keeping child handlers and the lock alive.
@@ -337,6 +349,7 @@ class ZarrGroupHandler:
             # and the three caches are disabled and empty, so reopening here
             # would be a pure extra round-trip on every write.
             self._group = self.reopen_group()
+            self._attrs_maybe_stale = False
         self._group_cache.clear()
         self._array_cache.clear()
         # Snapshot: a concurrent `get_handler` may insert mid-iteration.
@@ -403,10 +416,16 @@ class ZarrGroupHandler:
         if self._attrs_cache is not None:
             return deepcopy(self._attrs_cache)
         if self.use_cache:
-            # `self._group`, not a reopen: it is current by construction and
-            # refreshed by `invalidate_meta`, and its attributes are already in
-            # memory — so the first read of a cached handler costs nothing
-            # either, not just the repeats.
+            if self._attrs_maybe_stale:
+                # Constructed from a pre-opened caller group: its in-memory
+                # attributes may predate writes on the same store. One store
+                # read here, cached as usual from then on.
+                self._group = self.reopen_group()
+                self._attrs_maybe_stale = False
+            # `self._group`, not a reopen: it is current by construction (or
+            # just refreshed above) and refreshed by `invalidate_meta`, and its
+            # attributes are already in memory — so the first read of a cached
+            # handler costs nothing either, not just the repeats.
             attrs = self._group.attrs.asdict()
             self._attrs_cache = attrs
             return deepcopy(attrs)
@@ -552,6 +571,10 @@ class ZarrGroupHandler:
         handler = ZarrGroupHandler(
             store=group, zarr_format=self.zarr_format, cache=self.use_cache, mode=mode
         )
+        # `get_group` handed over a group that is current within this handler's
+        # caching regime (and invalidation cascades to the child); the
+        # pre-opened safety reopen would cost one read per child for nothing.
+        handler._attrs_maybe_stale = False
         if overwrite:
             # The group was just recreated (evicting the subtree); replace
             # rather than adopt whatever a racing builder may have cached.

--- a/tests/unit/images/test_create.py
+++ b/tests/unit/images/test_create.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import zarr
 from pydantic import ValidationError
 from zarr.storage import MemoryStore
 
@@ -494,3 +495,25 @@ def test_cross_format_derive_requires_explicit_compressors(tmp_path: Path):
         v2.derive_image(store=target_v3, ngff_version="0.5")
     assert not target_v3.exists()
     v2.derive_image(store=target_v3, ngff_version="0.5", compressors="auto")
+
+
+def test_create_from_array_in_preopened_group(tmp_path: Path):
+    """`store=<pre-opened zarr.Group>` must survive the internal cached reopen.
+
+    The canonical HCS-converter pattern hands `create_ome_zarr_from_array` a
+    live group (`plate.get_image_store(...)`). The populate step reopens that
+    group with `cache=True`; trusting the caller object's in-memory attributes
+    made it read `{}` where the just-written NGFF document should be.
+    """
+    group = zarr.open_group(tmp_path / "preopened.zarr", mode="a")
+    array = np.random.randint(0, 255, (64, 64), dtype="uint8")
+    ome_zarr = create_ome_zarr_from_array(
+        array=array,
+        store=group,
+        pixelsize=0.5,
+        axes_names=["y", "x"],
+        levels=2,
+        overwrite=True,
+    )
+    image = ome_zarr.get_image()
+    np.testing.assert_array_equal(image.get_as_numpy(), array)

--- a/tests/unit/utils/test_zarr_utils.py
+++ b/tests/unit/utils/test_zarr_utils.py
@@ -526,3 +526,23 @@ def test_writes_are_visible_through_a_stale_consolidated_metadata(tmp_path: Path
 
     assert handler.load_attrs()["members"] == ["added_after_consolidation"]
     assert "child" in handler.group
+
+
+def test_cached_handler_on_a_preopened_group_reads_fresh_attrs(tmp_path: Path):
+    """A `cache=True` handler must not pin a caller group's stale attributes.
+
+    A pre-opened `zarr.Group` carries the attributes from when the caller opened
+    it. Writes made since through another handler on the same store were
+    invisible to that snapshot, and `cache=True` trusted and pinned it — which
+    broke `create_ome_zarr_from_array(store=<pre-opened group>)`, whose cached
+    reopen saw `{}` where the just-written NGFF document should be.
+    """
+    store = tmp_path / "preopened.zarr"
+    caller_group = zarr.open_group(store, mode="a")
+
+    writer = ZarrGroupHandler(store=store, cache=False, mode="r+")
+    writer.write_attrs({"written": "after-caller-open"})
+    assert caller_group.attrs.asdict() == {}
+
+    cached = ZarrGroupHandler(store=caller_group, cache=True, mode="r+")
+    assert cached.load_attrs() == {"written": "after-caller-open"}


### PR DESCRIPTION
Two fixes for regressions found while migrating ome-zarr-converters-tools to 1.1.0a1 (BioVisionCenter/ome-zarr-converters-tools#72), gating v1.1.0a2.

## `cache=True` trusted a caller group's stale in-memory attributes

`create_ome_zarr_from_array(store=<pre-opened zarr.Group>)` raised `NgioValidationError` decoding `{}`: the populate step's cached reopen adopted the caller's group object and trusted the attributes it held from when the *caller* opened it — before the metadata write. This broke the canonical HCS-converter pattern `plate.get_image_store(...)` → `create_ome_zarr_from_array(...)`.

A `ZarrGroupHandler` built on a pre-opened group now takes its first cached attribute read from the store, then caches as usual. The internal construction sites that hand over known-current groups (`get_handler` child handlers, `reopen_handler`) skip the safety reopen, so cached plate walks pay zero extra reads — the op-count snapshots pass unchanged.

## `GenericRoiTableV1.from_table_data` returns `Self` again

The narrowed `-> "GenericRoiTableV1"` annotation made `RoiTableV1` fail the `Table` protocol under type checkers, flagging every downstream `add_table(name, roi_table)`. The body already returns `cls(...)`.

Regression tests for both (handler-level and converter-pattern-level); full suite 1380 passed, lint and `ty check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)