### PR TITLE
Fix: forward max_workers through get_images → images_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Stale table names are skipped by typed listings instead of *creating* a group for the missing table; shards clip to whole chunk multiples instead of producing a geometry zarr rejects; `mode="coarsen"` asked to upsample raises a named error instead of a bare divide-by-zero; a dropped channel selection is no longer validated before the removal that exempted it; a zero-sized axis reports itself instead of blaming the tail policy; stitch plan warnings fire at the start of `map`, pointing at the caller, not mid-run from a worker.
 - `create_ome_zarr_from_array(store=<pre-opened zarr.Group>)` failed validating `{}`: the populate step's cached reopen trusted the caller group's in-memory attributes, which predate the metadata write. A `cache=True` handler built on a pre-opened group now takes its first attribute read from the store — the canonical `plate.get_image_store(...) → create_ome_zarr_from_array(...)` converter pattern works again.
 - `GenericRoiTableV1.from_table_data` returns `Self` again, not the base class — the narrowed annotation made `RoiTableV1` fail the `Table` protocol under type checkers, flagging every downstream `add_table(name, roi_table)`.
+- `plate.get_images(max_workers=...)` forwards `max_workers` to its internal `images_paths()` listing. Dropping it on that hop kept the per-well walk serial and fired the plate fan-out `NgioFutureWarning` at callers who had already opted in — its own documented remedy could not silence it, transitively from every table helper built on `get_images`.
 
 ### Behaviour changes
 

--- a/src/ngio/hcs/_plate.py
+++ b/src/ngio/hcs/_plate.py
@@ -490,7 +490,7 @@ class OmeZarrPlate:
         Returns:
             A dictionary of images, keyed by image path.
         """
-        paths = self.images_paths(acquisition=acquisition)
+        paths = self.images_paths(acquisition=acquisition, max_workers=max_workers)
         images = _map_workers(self._get_image, paths, max_workers=max_workers)
         return dict(zip(paths, images, strict=True))
 

--- a/tests/unit/images/test_max_workers_default.py
+++ b/tests/unit/images/test_max_workers_default.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from ngio import create_empty_plate
+from ngio import create_empty_plate, create_ome_zarr_from_array
 from ngio.ome_zarr_meta import ImageInWellPath
 from ngio.utils import NgioFutureWarning
 
@@ -70,3 +71,44 @@ def test_the_notice_points_at_the_caller_not_at_ngio(plate):
     assert nested[0].filename == this_file
     # ...and they are distinct locations, so neither hides the other.
     assert direct[0].lineno != nested[0].lineno
+
+
+@pytest.fixture
+def populated_plate(tmp_path: Path):
+    images = [
+        ImageInWellPath(row="A", column="01", path="0"),
+        ImageInWellPath(row="A", column="02", path="0"),
+    ]
+    plate = create_empty_plate(
+        tmp_path / "populated.zarr", name="plate", images=images, overwrite=True
+    )
+    for column in ("01", "02"):
+        store = plate.get_image_store(row="A", column=column, image_path="0")
+        create_ome_zarr_from_array(
+            array=np.zeros((8, 8), dtype="uint8"),
+            store=store,
+            pixelsize=1.0,
+            axes_names=["y", "x"],
+            levels=1,
+            consolidation_mode="auto",
+        )
+    return plate
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda plate: plate.get_images(max_workers="auto"),
+        lambda plate: plate.list_image_tables(max_workers="auto"),
+    ],
+)
+def test_opting_in_silences_the_nested_fan_outs_too(populated_plate, call, recwarn):
+    """`max_workers="auto"` must reach every fan-out a call runs internally.
+
+    `get_images` lists paths through `images_paths` → `get_wells` before
+    opening anything; dropping the forward on that hop made the notice fire
+    at callers who had already opted in — transitively from every
+    table-listing helper built on `get_images`.
+    """
+    call(populated_plate)
+    assert [w for w in recwarn if issubclass(w.category, NgioFutureWarning)] == []


### PR DESCRIPTION
`plate.get_images(max_workers=...)` did not forward `max_workers` to its internal `images_paths()` call (`_plate.py:493`), so:

- the plate fan-out `NgioFutureWarning` fired even after the caller applied its own documented remedy (`max_workers="auto"`), which is fatal for `filterwarnings=["error"]` suites;
- the round-trip-bound per-well listing stayed serial regardless of the opt-in;
- every table helper built on `get_images` (`list_image_tables`, `concatenate_image_tables{,_as}`) inherited both.

Found independently by fractal-uzh-converters ([PR #54](https://github.com/fractal-analytics-platform/fractal-uzh-converters/pull/54)) and fractal-tasks-core ([PR #1069](https://github.com/fractal-analytics-platform/fractal-tasks-core/pull/1069)) during the 1.1.0a2 validation campaign.

One-line fix plus a regression test on a populated two-image plate (verified to fail pre-fix and pass post-fix); op-count snapshots unchanged, `hcs`/`images`/`performance` suites green, lint and `ty check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)