### PR TITLE
Public Image.resolve_channel_selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `NgioConfig` gained three sections, each with a public model: `zarr` (`ZarrConfig`), `dask` (`DaskConfig`), and `consolidation` (`ConsolidationConfig`).
 - Every `max_workers` accepts `"auto"`; `refresh()` on containers and plates re-reads all held metadata; the scheduling primitives (`plan_waves`, `canonical_unit_order`, `TailPolicy`, …) are public in `ngio.iterators`.
 - New public names: `NgioFutureWarning`, `ChannelSlicingInputType` (`ngio.images`), `ConsolidationMode` and `RegionsLike` (`ngio.common`), and `AbstractImage.write_granularity()` — the shape zarr writes atomically.
+- `Image.resolve_channel_selection(selection)` resolves anything the `get_*` methods accept as `channel_selection` — index, label, `ChannelSelectionModel`, or a sequence of those — to its slicing entry, touching only metadata. This is the supported way to validate a selection before loading data (Fractal tasks previously imported the private parser for their `skip_if_missing` checks).
 
 ### Fixes
 

--- a/src/ngio/images/_image.py
+++ b/src/ngio/images/_image.py
@@ -202,6 +202,23 @@ class Image(AbstractImage):
             channel_label=channel_label, wavelength_id=wavelength_id
         )
 
+    def resolve_channel_selection(
+        self, channel_selection: ChannelSlicingInputType = None
+    ) -> dict[str, int | list[int]]:
+        """Resolve a channel selection against this image's channel metadata.
+
+        Accepts everything the `get_*` methods accept as `channel_selection` —
+        an index, a channel label, a `ChannelSelectionModel`, or a sequence of
+        those — and returns the slicing entry it resolves to (`{"c": index}`
+        or `{"c": [indices]}`; `{}` for `None`), ready to use as slicing
+        kwargs. Resolution touches only metadata, so this is also the way to
+        validate a selection before loading any data.
+
+        Raises:
+            NgioValueError: If a referenced channel does not exist.
+        """
+        return _parse_channel_selection(self, channel_selection)
+
     def get_as_numpy(
         self,
         channel_selection: ChannelSlicingInputType = None,
@@ -1075,7 +1092,7 @@ def _parse_str_or_model(
 
 def _parse_channel_selection(
     image: Image, channel_selection: ChannelSlicingInputType
-) -> dict[str, SlicingInputType]:
+) -> dict[str, int | list[int]]:
     """Parse the channel selection input into a list of channel indices."""
     if channel_selection is None:
         return {}

--- a/tests/unit/images/test_image_api.py
+++ b/tests/unit/images/test_image_api.py
@@ -123,3 +123,28 @@ def test_channel_selection_ambiguous_with_c_kwarg():
     image = _make_container().get_image()
     with pytest.raises(NgioValueError, match="ambiguous"):
         image.get_array(channel_selection=0, c=0)
+
+
+def test_resolve_channel_selection():
+    """The public resolver mirrors what the `get_*` methods accept.
+
+    Resolution touches only metadata — this is the supported way to validate
+    a selection (e.g. a task's `skip_if_missing`) before loading any data.
+    """
+    image = _make_container().get_image()
+
+    assert image.resolve_channel_selection(None) == {}
+    assert image.resolve_channel_selection(1) == {"c": 1}
+    assert image.resolve_channel_selection("GFP") == {"c": 1}
+    assert image.resolve_channel_selection(["DAPI", "GFP"]) == {"c": [0, 1]}
+    assert image.resolve_channel_selection(
+        [
+            ChannelSelectionModel(mode="wavelength_id", identifier="A02_C02"),
+            ChannelSelectionModel(mode="index", identifier="0"),
+        ]
+    ) == {"c": [1, 0]}
+
+    with pytest.raises(NgioValueError):
+        image.resolve_channel_selection("not_a_channel")
+    with pytest.raises(NgioValueError):
+        image.resolve_channel_selection(["DAPI", 7])


### PR DESCRIPTION
ngio exports `ChannelSelectionModel` and encourages tasks to accept it in their pydantic interfaces, but offered no public way to resolve or validate one against an image. Both [fractal-tasks-core #1069](https://github.com/fractal-analytics-platform/fractal-tasks-core/pull/1069) and [fractal-cellpose-sam-task #34](https://github.com/fractal-analytics-platform/fractal-cellpose-sam-task/pull/34) import the private `_parse_channel_selection` purely to probe whether a selection resolves (their `skip_if_missing` features) before running an expensive model — it is tasks-core's last remaining private ngio import.

`Image.resolve_channel_selection(selection)` accepts everything the `get_*` methods accept as `channel_selection` — index, label, `ChannelSelectionModel`, or a sequence of those — and returns the slicing entry it resolves to (`{"c": index}` / `{"c": [indices]}` / `{}` for `None`), touching only metadata; unknown channels raise `NgioValueError`. Implementation delegates to the existing parser, whose return annotation is tightened to what it actually produces.

Requested during the 1.1.0a2 consumer-validation campaign; targeted at v1.1.0b1 alongside #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)